### PR TITLE
Fix duplicated loading on the same file breaking the page

### DIFF
--- a/src/modules/Player.js
+++ b/src/modules/Player.js
@@ -101,8 +101,10 @@ export default class Player extends Component {
   }
 
   pause() {
-    this.oscillator.onended = undefined;
-    this.oscillator.stop();
+    if (this.oscillator) {
+      this.oscillator.onended = undefined;
+      this.oscillator.stop();
+    }
     this.setState({ playing: false });
   }
 


### PR DESCRIPTION
Click the load button twice when focusing on the same file and the page will become blank completely.
Console shows that this.oscillator is undefined.
The patch checks it to be true before calling its method.